### PR TITLE
Allow ruby version override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 .env
 coverage
+.ruby-version
 
 # Ignore bundler config.
 /.bundle

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-# Default to 2.3.3 but allow override for development
-ruby File.exist?('.ruby-version') ? File.read('.ruby-version') : '2.3.3'
+# Default to 2.3.4 but allow override for development
+ruby File.exist?('.ruby-version') ? File.read('.ruby-version') : '2.3.4'
 
 gem 'rails', '~> 5.0.0', '>= 5.0.0.1'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
-ruby '2.3.3'
+# Default to 2.3.3 but allow override for development
+ruby File.exist?('.ruby-version') ? File.read('.ruby-version') : '2.3.3'
 
 gem 'rails', '~> 5.0.0', '>= 5.0.0.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,7 +230,7 @@ DEPENDENCIES
   web-console
 
 RUBY VERSION
-   ruby 2.3.3p222
+   ruby 2.3.4p301
 
 BUNDLED WITH
    1.15.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,4 +233,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.14.6
+   1.15.1


### PR DESCRIPTION
Pkgr will see 'ruby 2.3.4' but in development/CI you can override using rbenv or rvm.

I also bumped the version from 2.3.3 to 2.3.4 since that's been stable for over 2 months now.